### PR TITLE
modified regular expression to exclude blank lines.

### DIFF
--- a/rdumpfs
+++ b/rdumpfs
@@ -28,7 +28,7 @@ src=("${@:1:$#-1}")
 dst=${!#}
 
 now=$(date +%Y%m%d)
-dumps=($(rsync --no-h $dst/ | cut -c44- | grep '^[0-9]*$' | sort -nr))
+dumps=($(rsync --no-h $dst/ | cut -c44- | grep '^[0-9]\+$' | sort -nr))
 last=${dumps[0]}
 
 : ${RDUMPFS_DEFAULT_ARGS:=-aHAX}

--- a/rdumpfs
+++ b/rdumpfs
@@ -28,7 +28,7 @@ src=("${@:1:$#-1}")
 dst=${!#}
 
 now=$(date +%Y%m%d)
-dumps=($(rsync --no-h $dst/ | cut -c44- | grep '^[0-9]\+$' | sort -nr))
+dumps=($(rsync --no-h $dst/ | cut -c44- | grep '^[0-9]\{8\}$' | sort -nr))
 last=${dumps[0]}
 
 : ${RDUMPFS_DEFAULT_ARGS:=-aHAX}


### PR DESCRIPTION
The original expression allows for blank lines.  The proposed one requires at least one number in the line.  The reason for the \ is that grep's syntax requires a \ for the + operator, but not for the * operator.